### PR TITLE
Update dependencies

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -1,5 +1,5 @@
 cdt_name:
-- cos6
+- cos7
 channel_sources:
 - conda-forge
 channel_targets:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ build:
   entry_points:
     - copier = copier.cli:CopierApp.run
   script: {{ PYTHON }} -m pip install . -vv
-  number: 0
+  number: 1
   noarch: python
 
 requirements:
@@ -26,7 +26,7 @@ requirements:
     - colorama >=0.4.6
     - dunamai >=1.7.0
     - funcy >=1.17
-    - jinja2 >=3.1.3
+    - jinja2 >=3.1.4
     - jinja2-ansible-filters >=1.3.1
     - packaging >=23.0
     - pathspec >=0.9.0
@@ -38,6 +38,7 @@ requirements:
     - questionary >=1.8.1
     - git >=2.27
     - typing-extensions >=3.7.4,<5.0.0
+    - eval-type-backport >=0.1.3,<0.3.0
 
 test:
   imports:


### PR DESCRIPTION
eval-type-backport is only needed for python<3.10, but specifying that would break `noarch`

See https://github.com/copier-org/copier/compare/v9.2.0...v9.3.0#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
